### PR TITLE
Revert "Upgrade react-copy-to-clipboard: 5.0.1 → 5.0.2 (patch)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "qrcode.react": "0.8.0",
     "query-string": "6.2.0",
     "react": "^16.4.0",
-    "react-copy-to-clipboard": "5.0.2",
+    "react-copy-to-clipboard": "5.0.1",
     "react-dom": "^16.4.0",
     "react-redux": "^5.0.7",
     "react-router": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6727,10 +6727,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-copy-to-clipboard@5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.2.tgz#d82a437e081e68dfca3761fbd57dbf2abdda1316"
-  integrity sha512-/2t5mLMMPuN5GmdXo6TebFa8IoFxZ+KTDDqYhcDm0PhkgEzSxVvIX26G20s1EB02A4h2UZgwtfymZ3lGJm0OLg==
+react-copy-to-clipboard@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  integrity sha512-ELKq31/E3zjFs5rDWNCfFL4NvNFQvGRoJdAKReD/rUPA+xxiLPQmZBZBvy2vgH7V0GE9isIQpT9WXbwIVErYdA==
   dependencies:
     copy-to-clipboard "^3"
     prop-types "^15.5.8"


### PR DESCRIPTION
Reverts bumi/joule-extension#9

with this update I do get the following error when paying an invice. 
```
Uncaught (in promise) {}
wrappedSendMessageCallback | @ | browser-polyfill.js:1120
```


![image](https://user-images.githubusercontent.com/318/83691646-d2787600-a5f2-11ea-9298-0f3b37f76104.png)
